### PR TITLE
Implement functions for SRelativistic quantities.

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,125 @@
-function pc_ref(species::Species, beta_0)
-  return "hi!"
+"""
+utilities.jl
+"""
+
+
+"""
+    sr_gamma(beta_gamma)
+
+For a particle with relativistic parameter ``\\beta\\gamma``,
+compute the relativistic Lorentz factor ``\\gamma``.
+"""
+function sr_gamma(beta_gamma)
+  return hypot(1, beta_gamma)
 end
+
+
+"""
+    sr_gamma_m1(beta_gamma)
+
+For a particle with relativistic parameter ``\\beta\\gamma``,
+compute the relativistic Lorentz factor minus one, ``\\gamma - 1``.
+"""
+function sr_gamma_m1(beta_gamma)
+  return beta_gamma^2 / (hypot(1, beta_gamma) + 1)
+end
+
+
+"""
+    sr_beta(beta_gamma)
+
+For a particle with relativistic parameter ``\\beta\\gamma``,
+compute the normalized velocity ``\\beta = v / c``.
+"""
+function sr_beta(beta_gamma)
+  return beta_gamma / hypot(1, beta_gamma)
+end
+
+
+"""
+    sr_pc(e_rest, beta_gamma)
+
+For a particle with a given rest energy and relativistic parameter
+``\\beta\\gamma``, compute the energy-equivalent momentum, ``pc``.
+"""
+function sr_pc(e_rest, beta_gamma)
+  return e_rest * beta_gamma
+end
+
+
+"""
+    sr_ekin(e_rest, beta_gamma)
+
+For a particle with a given rest energy and relativistic parameter
+``\\beta\\gamma``, compute the kinetic energy,
+``E_\\text{kin} = mc^2(\\gamma - 1)``.
+"""
+function sr_ekin(e_rest, beta_gamma)
+  return e_rest * sr_gamma_m1(beta_gamma)
+end
+
+
+"""
+    sr_etot(e_rest, beta_gamma)
+
+For a particle with a given rest energy and relativistic parameter
+``\\beta\\gamma``, compute the total energy, ``E_\\tot = mc^2\\gamma``.
+"""
+function sr_ekin(e_rest, beta_gamma)
+  return e_rest * hypot(1, beta_gamma)
+end
+
+
+"""
+    brho(e_rest, beta_gamma, ne = 1)
+
+For a particle with a given rest energy and relativistic parameter
+``\\beta\\gamma``, compute the magnetic rigidity, ``B\\rho = p / q``.
+
+DTA: Need to handle energy units other than ``\\mathrm{eV}``..
+"""
+function brho(e_rest, beta_gamma, ne = 1)
+  return sr_pc(e_rest, beta_gamma) / (ne * clight)
+end
+
+
+## If given ``E_\text{kin}`` instead of ``\beta\gamma``, use the following:
+#function sr_gamma(e_rest, e_kin)
+#  return e_kin / e_rest + 1
+#end
+#
+#function sr_gamma_m1(e_rest, e_kin)
+#  return e_kin / e_rest
+#end
+#
+#function sr_beta_gamma(e_rest, e_kin)
+#  return sqrt(e_kin / e_rest * (e_kin / e_rest + 2))
+#end
+#
+#function sr_beta(e_rest, e_kin)
+#  return sr_beta_gamma(e_rest, e_kin) / sr_gamma(e_rest, e_kin)
+#end
+#
+#function sr_pc(e_rest, e_kin)
+#  #return sqrt(e_kin * (e_kin + 2e_rest))
+#  return e_rest * sr_beta_gamma(e_rest, e_kin)
+#end
+#
+#function sr_etot(e_rest, e_kin)
+#  return e_rest + e_kin
+#end
+#
+#function brho(e_rest, e_kin, ne = 1)
+#  return sr_pc(e_rest, e_kin) / (ne * clight)
+#end
+
+
+
+export sr_gamma,
+       sr_gamma_m1,
+       sr_beta,
+       sr_pc,
+       sr_ekin,
+       sr_etot,
+       brho
+

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,8 @@
-"""
-utilities.jl
-"""
+#=
+
+Utility functions needed for tracking.
+
+=#
 
 
 """
@@ -83,7 +85,9 @@ function brho(e_rest, beta_gamma, ne = 1)
 end
 
 
-## If given ``E_\text{kin}`` instead of ``\beta\gamma``, use the following:
+## If given ``E_\text{kin}`` instead of ``\beta\gamma``,
+## use the following:
+#
 #function sr_gamma(e_rest, e_kin)
 #  return e_kin / e_rest + 1
 #end
@@ -112,14 +116,4 @@ end
 #function brho(e_rest, e_kin, ne = 1)
 #  return sr_pc(e_rest, e_kin) / (ne * clight)
 #end
-
-
-
-export sr_gamma,
-       sr_gamma_m1,
-       sr_beta,
-       sr_pc,
-       sr_ekin,
-       sr_etot,
-       brho
 


### PR DESCRIPTION
This PR provides implementations of functions to compute accurate values
for a range of relativistic parameters and quantities — $\gamma$, $\gamma - 1$, $\beta$, $pc$, $E_\text{kin}$, $E_\text{tot}$,
and $B\rho$ — given values for the rest energy, $mc^2$, and $\beta\gamma$.

Items to address / comment on:
- [ ] function names
- [ ] function arguments — use E_\text{kin} instead of $\beta\gamma$?
- [ ] docstrings

The definitions given here will require corresponding changes to the tracking
routines. Should those changes be made part of this PR?