### PR TITLE
Purely positive `p0c`, `brho`

### DIFF
--- a/src/modules/ExactTracking.jl
+++ b/src/modules/ExactTracking.jl
@@ -447,7 +447,7 @@ function w_inv_matrix(x_rot, y_rot, z_rot)
 end
 
 function drift_params(species::Species, Brho)
-  beta_gamma_0 = BeamTracking.calc_beta_gammma(species, Brho)
+  beta_gamma_0 = BeamTracking.calc_beta_gamma(species, Brho)
   tilde_m = 1/beta_gamma_0
   gamsqr_0 = @FastGTPSA 1+beta_gamma_0^2
   beta_0 = @FastGTPSA beta_gamma_0/sqrt(gamsqr_0)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -130,12 +130,12 @@ massof(s::Species) = s.mass
 chargeof(s::Species) = s.charge
 
 # Particle energy conversions =============================================================
-calc_Brho(species::Species, E) = @FastGTPSA sqrt(E^2-massof(species)^2)/C_LIGHT/chargeof(species)
+calc_Brho(species::Species, E) = @FastGTPSA sqrt(E^2-massof(species)^2)/C_LIGHT/abs(chargeof(species))
 calc_E(species::Species, Brho) = @FastGTPSA sqrt((Brho*C_LIGHT*chargeof(species))^2 + massof(species)^2)
 calc_gamma(species::Species, Brho) = @FastGTPSA sqrt((Brho*C_LIGHT/massof(species))^2+1)
 
-calc_p0c(species::Species, Brho) = @FastGTPSA Brho*C_LIGHT*chargeof(species)
-calc_beta_gammma(species::Species, Brho) = @FastGTPSA Brho*chargeof(species)*C_LIGHT/massof(species)
+calc_p0c(species::Species, Brho) = @FastGTPSA Brho*C_LIGHT*abs(chargeof(species))
+calc_beta_gamma(species::Species, Brho) = @FastGTPSA Brho*abs(chargeof(species))*C_LIGHT/massof(species)
 
 
 


### PR DESCRIPTION
The convention for `Brho` and `p0c` is that they are both positive for +/- charge, so I've made this change in internal calculations.

In the future, we may want to store the direction (up/down) of the holding dipole field in a different place.