### PR TITLE
Add macro-particle weight to Coords struct

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ function test_matrix(
   v = transpose(@vars(D1))
   state = similar(v, UInt8, 1)
   state .= STATE_ALIVE
-  coords = Coords(state, v, nothing)
+  coords = Coords(state, v, nothing, nothing)
 
   # Set up kernel chain and launch!
   BeamTracking.launch!(coords, kernel_call)
@@ -60,7 +60,7 @@ function test_matrix(
     q = repeat([1.0 0.0 0.0 0.0], 2)
     state = [STATE_ALIVE STATE_ALIVE]
     @test @ballocated(BeamTracking.launch!(coords, $kernel_call; use_KA=false), 
-    setup=(coords = Coords(copy($state), copy($v), copy($q)))) == 0
+    setup=(coords = Coords(copy($state), copy($v), copy($q), nothing))) == 0
   end
 end
 
@@ -104,7 +104,7 @@ function test_map(
   q = TPS64{D10}[1 0 0 0]
   state = similar(v, UInt8, 1)
   state .= STATE_ALIVE
-  coords = Coords(state, v, q)
+  coords = Coords(state, v, q, nothing)
 
   # Set up kernel chain and launch!
   BeamTracking.launch!(coords, kernel_call)
@@ -121,7 +121,7 @@ function test_map(
     q = repeat([1.0 0.0 0.0 0.0], 2)
     state = [STATE_ALIVE STATE_ALIVE]
     @test @ballocated(BeamTracking.launch!(coords, $kernel_call; use_KA=false), 
-    setup=(coords = Coords(copy($state), copy($v), copy($q)))) == 0
+    setup=(coords = Coords(copy($state), copy($v), copy($q), nothing))) == 0
   end
 
 


### PR DESCRIPTION
`weight` is a weighting factor typically used when macro-particles are being simulated. It is optional and defaults to nothing. 