### PR TITLE
Add PythonCall extension: TimeDependentParam/BatchParam from Python

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -64,8 +64,9 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GTPSA = "b27dd330-f138-47c5-815b-40db9dd9b6e8"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Distributions", "JET", "GTPSA", "BenchmarkTools", "Beamlines", "StaticArrays", "LinearAlgebra"]
+test = ["Test", "Distributions", "JET", "GTPSA", "BenchmarkTools", "Beamlines", "StaticArrays", "LinearAlgebra", "PythonCall"]

--- a/Project.toml
+++ b/Project.toml
@@ -27,9 +27,11 @@ Unrolled = "9602ed7d-8fef-5bc8-8597-8f21381861e8"
 [weakdeps]
 Beamlines = "5bb90b03-0719-46b8-8ce4-1ef3afd3cd4b"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [extensions]
 BeamTrackingBeamlinesExt = "Beamlines"
+BeamTrackingPythonCallExt = "PythonCall"
 
 [compat]
 Accessors = "0.1.42"
@@ -44,6 +46,7 @@ HostCPUFeatures = "0.1"
 KernelAbstractions = "0.9.35"
 LinearAlgebra = "1"
 MacroTools = "0.5.16"
+PythonCall = "0.9"
 ReferenceFrameRotations = "3"
 SIMD = "3.7.1"
 SIMDMathFunctions = "0.1.3"

--- a/ext/BeamTrackingPythonCallExt/BeamTrackingPythonCallExt.jl
+++ b/ext/BeamTrackingPythonCallExt/BeamTrackingPythonCallExt.jl
@@ -1,0 +1,43 @@
+module BeamTrackingPythonCallExt
+using PythonCall
+import BeamTracking: TimeDependentParam, BatchParam
+
+# Construction of BeamTracking's deferred-parameter types from Python objects.
+#
+# `TimeDependentParam` and `BatchParam` are not `Number` subtypes, so juliacall
+# neither overloads their operators nor converts Python callables/sequences into
+# them automatically. These methods let a Python callable become a
+# time-dependent parameter, and a Python sequence become a batch parameter,
+# converting values to `T` (default `Float64`) at evaluation time.
+#
+# Operator overloading on the *Python* side (so `2 * Time() + 1` works from
+# Python) is provided by the operators these Julia types already define; a Python
+# wrapper only needs to forward `+ - * / ^` onto them.
+
+_pycallable(f::Py) = pytruth(pybuiltins.callable(f))
+
+# --- TimeDependentParam ------------------------------------------------------
+
+function TimeDependentParam(f::Py, ::Type{T}) where {T}
+  if _pycallable(f)
+    return TimeDependentParam(t -> pyconvert(T, f(t)), false)
+  else
+    return TimeDependentParam(pyconvert(T, f))  # a constant
+  end
+end
+
+TimeDependentParam(f::Py) = TimeDependentParam(f, Float64)
+
+# --- BatchParam --------------------------------------------------------------
+
+function BatchParam(batch::Py, ::Type{T}) where {T}
+  if pyhasattr(batch, "__len__")           # a sequence (list/tuple/ndarray/...)
+    return BatchParam(pyconvert(Vector{T}, batch))
+  else
+    return BatchParam(pyconvert(T, batch))  # a scalar (degenerate batch)
+  end
+end
+
+BatchParam(batch::Py) = BatchParam(batch, Float64)
+
+end

--- a/test/PythonCallExt_test.jl
+++ b/test/PythonCallExt_test.jl
@@ -1,0 +1,18 @@
+# Exercises BeamTrackingPythonCallExt: constructing TimeDependentParam / BatchParam
+# from Python objects. Requires PythonCall (which provisions Python via CondaPkg
+# on first use).
+@testset "BeamTrackingPythonCallExt" begin
+  # TimeDependentParam from a Python callable f(t)
+  tdp = TimeDependentParam(pyeval(Py, "lambda t: 2*t + 1", Main))
+  @test tdp(3.0) == 7.0
+
+  # constant TimeDependentParam from a Python value
+  @test TimeDependentParam(pyeval(Py, "5.0", Main))(0.0) == 5.0
+
+  # BatchParam from a Python sequence
+  bp = BatchParam(pyeval(Py, "[0.1, 0.2, 0.3]", Main))
+  @test collect(Float64, bp.batch) == [0.1, 0.2, 0.3]
+
+  # BatchParam scalar (degenerate batch) from a Python value
+  @test BatchParam(pyeval(Py, "0.5", Main)).batch == 0.5
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,8 @@ using Test,
       ReferenceFrameRotations,
       SIMD,
       KernelAbstractions,
-      ForwardDiff
+      ForwardDiff,
+      PythonCall
 
 using BeamTracking: Coords, KernelCall, make_kernel_call, Q0, QX, QY, QZ, STATE_ALIVE, STATE_LOST, C_LIGHT,
       STATE_LOST_NEG_X, STATE_LOST_POS_X, STATE_LOST_NEG_Y, STATE_LOST_POS_Y, STATE_LOST_PZ, STATE_LOST_Z,
@@ -218,3 +219,4 @@ include("IntegrationTracking_test.jl")
 include("collective_test.jl")
 include("callback_test.jl")
 include("ImplicitTracking_test.jl")
+include("PythonCallExt_test.jl")


### PR DESCRIPTION
Part of the Python-interface work for bmad-sim/SciBmad.jl#76.

## What

New `BeamTrackingPythonCallExt` package extension so BeamTracking's deferred-parameter types can be constructed from Python objects handed over via juliacall/PythonCall:

```python
TimeDependentParam(lambda t: 2*t + 1)   # from a Python callable
TimeDependentParam(5.0)                 # constant
BatchParam([0.1, 0.2, 0.3])             # from a Python sequence
```

Adds `PythonCall` as a weakdep + `[extensions]` entry + `[compat]` in `Project.toml`, and the extension module with:

- `TimeDependentParam(::Py[, ::Type{T}])`
- `BatchParam(::Py[, ::Type{T}])`

converting values to `T` (default `Float64`).

## Why

`TimeDependentParam` and `BatchParam` are not `Number` subtypes, so juliacall neither converts a Python callable/sequence into them nor overloads their operators automatically. Per #76, the fix lives as a PythonCall extension in the package where the functionality is defined. Operator overloading on the Python side is handled by a thin wrapper forwarding onto the operators these Julia types already define; this PR only needs to make construction work.

## Scope / notes

- No change to existing code paths; the new methods dispatch only on `::Py`.
- A Python callable is invoked per evaluation, which requires the GIL and so is CPU-only. This is inherent to any Python callback and matches how the `scibmad` package behaves today.
- `BatchParam` treats a Python object with `__len__` as a sequence, otherwise a scalar (degenerate) batch.

## Testing

Verified via juliacall (with `BeamTracking` + `PythonCall` dev-loaded, extension auto-loading confirmed) that `TimeDependentParam(lambda t: 2*t+1)(3.0) == 7.0`, the constant form, and `BatchParam([0.1, 0.2, 0.3])` all work. Opened as a **draft** since I could not run the full BeamTracking.jl CI locally; a `PythonCall` test target could be added if wanted.
