### PR TITLE
Do not assume ForwardDiff duals carry 6 partials in implicit_step!

### DIFF
--- a/src/kernels/implicit.jl
+++ b/src/kernels/implicit.jl
@@ -1,3 +1,14 @@
+# A ForwardDiff.Dual carries however many partials the caller asked for: 6 when differentiating
+# with respect to the full 6D phase space, but e.g. 4 for a coasting-beam closed orbit search.
+# The Jacobian of the incoming coordinates must therefore be built generically in that number,
+# never assuming 6 partials are present.
+@inline _partials_row(x) = transpose(SVector(ForwardDiff.partials(x).values))
+
+@inline _partials_jacobian(x1, x2, x3, x4, x5, x6) =
+  vcat(_partials_row(x1), _partials_row(x2), _partials_row(x3),
+       _partials_row(x4), _partials_row(x5), _partials_row(x6))
+
+
 function implicit_integrator!(i, coords::Coords, s, radiation_params, beta_0, tilde_m, a, g, w, w_inv, potential_and_jac::U, potential_params, p_over_q_ref, normalized, implicit_use_newton, L) where {U}
   @inbounds begin @FastGTPSA begin
     s += L / 2
@@ -124,20 +135,9 @@ function implicit_step!(i, coords::Coords, s, beta_0, tilde_m, g, potential_and_
                Mpx[2,1] Mpp[2,1] Mpx[2,2] Mpp[2,2] Mpx[2,3] Mpp[2,3];
                Mxx[3,1] Mxp[3,1] Mxx[3,2] Mxp[3,2] Mxx[3,3] Mxp[3,3];
                Mpx[3,1] Mpp[3,1] Mpx[3,2] Mpp[3,2] Mpx[3,3] Mpp[3,3]]
-      r1 = ForwardDiff.partials(v[i,1]).values
-      r2 = ForwardDiff.partials(v[i,2]).values
-      r3 = ForwardDiff.partials(v[i,3]).values
-      r4 = ForwardDiff.partials(v[i,4]).values
-      r5 = ForwardDiff.partials(v[i,5]).values
-      r6 = ForwardDiff.partials(v[i,6]).values
-      jac_orig = SA[r1[1] r1[2] r1[3] r1[4] r1[5] r1[6];
-                    r2[1] r2[2] r2[3] r2[4] r2[5] r2[6];
-                    r3[1] r3[2] r3[3] r3[4] r3[5] r3[6];
-                    r4[1] r4[2] r4[3] r4[4] r4[5] r4[6];
-                    r5[1] r5[2] r5[3] r5[4] r5[5] r5[6];
-                    r6[1] r6[2] r6[3] r6[4] r6[5] r6[6]]
+      jac_orig = _partials_jacobian(v[i,1], v[i,2], v[i,3], v[i,4], v[i,5], v[i,6])
       jac_new = jac * jac_orig
-      V = eltype(v).parameters[1]
+      V = ForwardDiff.tagtype(eltype(v))
       new_x  = ForwardDiff.Dual{V}(v_new[XI],  Tuple(jac_new[XI,:]))
       new_y  = ForwardDiff.Dual{V}(v_new[YI],  Tuple(jac_new[YI,:]))
       new_z  = ForwardDiff.Dual{V}(v_new[ZI],  Tuple(jac_new[ZI,:]))
@@ -225,18 +225,7 @@ function implicit_step!(i, coords::Coords, s, beta_0, tilde_m, g, potential_and_
                Mpx[2,1] Mpp[2,1] Mpx[2,2] Mpp[2,2] Mpx[2,3] Mpp[2,3];
                Mxx[3,1] Mxp[3,1] Mxx[3,2] Mxp[3,2] Mxx[3,3] Mxp[3,3];
                Mpx[3,1] Mpp[3,1] Mpx[3,2] Mpp[3,2] Mpx[3,3] Mpp[3,3]]
-      r1 = ForwardDiff.partials(v_final[1]).values
-      r2 = ForwardDiff.partials(v_final[2]).values
-      r3 = ForwardDiff.partials(v_final[3]).values
-      r4 = ForwardDiff.partials(v_final[4]).values
-      r5 = ForwardDiff.partials(v_final[5]).values
-      r6 = ForwardDiff.partials(v_final[6]).values
-      jac_orig = SA[r1[1] r1[2] r1[3] r1[4] r1[5] r1[6];
-                    r2[1] r2[2] r2[3] r2[4] r2[5] r2[6];
-                    r3[1] r3[2] r3[3] r3[4] r3[5] r3[6];
-                    r4[1] r4[2] r4[3] r4[4] r4[5] r4[6];
-                    r5[1] r5[2] r5[3] r5[4] r5[5] r5[6];
-                    r6[1] r6[2] r6[3] r6[4] r6[5] r6[6]]
+      jac_orig = _partials_jacobian(v_final[1], v_final[2], v_final[3], v_final[4], v_final[5], v_final[6])
       jac_new = jac * jac_orig
       new_x  = ForwardDiff.Dual{V}(v_new[XI],  Tuple(jac_new[XI,:]))
       new_y  = ForwardDiff.Dual{V}(v_new[YI],  Tuple(jac_new[YI,:]))

--- a/test/ImplicitTracking_test.jl
+++ b/test/ImplicitTracking_test.jl
@@ -125,6 +125,22 @@ end
   end
   @test ForwardDiff.jacobian(track_crazy, [0.01, 0.02, 0.03, 0.04, 0.05, 0.06]) ≈ M
 
+  # ForwardDiff with a number of partials other than 6, as done by e.g. a coasting-beam
+  # closed orbit search which differentiates with respect to x, px, y, py only
+  function track_crazy_coast(v_coast)
+    b0 = Bunch([v_coast[1] v_coast[2] v_coast[3] v_coast[4] 0.05 0.06])
+    order_eight_integrator!(1, b0.coords, args...)
+    return b0.coords.v'
+  end
+  @test ForwardDiff.jacobian(track_crazy_coast, [0.01, 0.02, 0.03, 0.04]) ≈ M[:,1:4]
+
+  function track_crazy_1(w)
+    b0 = Bunch([0.01 + w[1] 0.02 0.03 0.04 0.05 0.06])
+    order_eight_integrator!(1, b0.coords, args...)
+    return b0.coords.v'
+  end
+  @test ForwardDiff.jacobian(track_crazy_1, [0.0]) ≈ M[:,1:1]
+
   # Type stability and no scalar allocations
   M = [0.5642361394656592    0.9695143326521845   0.0008233255950771141 0.23459732508210268 -3.98096261096381e-10  0.26202087937470775; 
       -0.543530422071873     0.762355986589084    0.005384939535613539  0.5568726180598322  -1.5243574558899086e-9 0.036470556982992404; 


### PR DESCRIPTION
Fixes bmad-sim/SciBmad.jl#83 and bmad-sim/SciBmad.jl#87 (the same bug), where `find_closed_orbit`/`twiss` on a lattice with wigglers dies with

```
[72874] signal 4 (1): Illegal instruction: 4
getindex at ./tuple.jl:31 [inlined]
implicit_step! at BeamTracking/src/kernels/implicit.jl:132
```

## The bug

`implicit_step!` rebuilds the Jacobian of the incoming coordinates from the duals' partials with a hard-coded width of 6:

```julia
r1 = ForwardDiff.partials(v[i,1]).values
jac_orig = SA[r1[1] r1[2] r1[3] r1[4] r1[5] r1[6];
              ...
```

But the number of partials is chosen by whoever is differentiating, and it is not always 6. `SciBmad.find_closed_orbit` on a ring with the RF off takes its coasting-beam branch and differentiates with respect to `x, px, y, py` only, so the coordinates arrive as `Dual{tag,Float64,4}` and `r1[5]`/`r1[6]` read past the end of a 4-tuple. Since the kernel body is inside `@inbounds`, the bounds check is elided and `getfield` traps instead of throwing a `BoundsError` — hence a SIGILL rather than a Julia error.

Any element that routes to the implicit integrator (i.e. carries `FourPotentialParams`, such as a wiggler) hits this; a coasting closed orbit through such a lattice always crashes. This also explains why `AutoFiniteDiff()` sidesteps it (as noted in SciBmad.jl#83) — finite differences never construct duals, so the kernel never sees a partial count other than 6.

## The fix

Build `jac_orig` generically in the number of partials. `jac * jac_orig` and the `Dual` reconstructions below already work for any number, so that is the whole change. Both call sites in `implicit_step!` are affected.

Also switched `eltype(v).parameters[1]` to `ForwardDiff.tagtype(eltype(v))` while touching those lines.

## Verification

Reduced reproducer at the kernel level (no SciBmad involved), using the existing `crazy` four-potential and reference matrix `M` from `test/ImplicitTracking_test.jl`:

* before: 4-partial `ForwardDiff.jacobian` through `order_eight_integrator!` → SIGILL at `implicit.jl:133` on current `main`;
* after: it returns a 6×4 Jacobian agreeing with `M[:,1:4]` to 3.6e-10 (the implicit root finder's tolerance). 1, 3 and 8 partials also agree with the corresponding columns.

Backporting the same change onto the released v0.7.0 that SciBmad currently resolves to, the lattice from SciBmad.jl#87 gets through closed orbit finding and tracking with no crash. (That lattice then fails later in `NonlinearNormalForm` with "At least one orbital eigenmode is linearly unstable!", which is a separate matter from this crash.)

Regression tests added next to the existing 6-partial ForwardDiff test in `test/ImplicitTracking_test.jl` covering 4 and 1 partials.

No version bump here — `main` is already at 0.8.0 and unreleased; say the word if you'd rather this be registered as a patch on 0.7.x too, since that is what SciBmad currently uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
