### PR TITLE
Absolute time tracking

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,3 +23,16 @@ same as the ending position with body coordinates. Thus the drifting transformat
 of phase space `z` is different than the standard `z` transformation for an element that is a drift. 
 A similar situation happens when the particle exits the element and there is a transformation
 from body coordinate to branch coordinates along with a "drift" to the nominal downstream edge.
+
+
+## RF phase and absolute time
+
+By default, RF cavities use relative-time tracking: `phi0` is the phase seen by the
+reference particle at each cavity, independent of the bunch reference time. Pass
+`absolute_time_tracking=true` to `track!` to phase-lock every cavity to the global
+reference time carried by `bunch.t_ref`. In this mode the phase seen by a particle is
+shifted by `2*pi*rf_frequency*bunch.t_ref`, enabling effects caused by changes in the
+physical RF frequency, such as radial steering.
+
+The default remains relative-time tracking for compatibility with lattices whose cavity
+phases are specified locally.

--- a/ext/BeamTrackingBeamlinesExt/BeamTrackingBeamlinesExt.jl
+++ b/ext/BeamTrackingBeamlinesExt/BeamTrackingBeamlinesExt.jl
@@ -16,6 +16,7 @@ function track!(
   ramp_particle_energy_without_rf::Bool=false,
   ramp_update_each_particle::Bool=false,
   rf_on::Bool=true,
+  absolute_time_tracking::Bool=false,
   _p_over_q_ref=nothing,
   context=(haskey(getfield(ele, :pdict), BeamlineParams) ? ele.beamline.context : Beamlines.NULL_CONTEXT),
   kwargs...
@@ -26,7 +27,7 @@ function track!(
     p_over_q_ref = _p_over_q_ref
   end
   coords = bunch.coords
-  @noinline _track!(coords, bunch, ele, context, p_over_q_ref, ele.tracking_method, scalar_params, ramp_particle_energy_without_rf, ramp_update_each_particle, rf_on; kwargs...)
+  @noinline _track!(coords, bunch, ele, context, p_over_q_ref, ele.tracking_method, scalar_params, ramp_particle_energy_without_rf, ramp_update_each_particle, rf_on, absolute_time_tracking; kwargs...)
   return bunch
 end
 
@@ -37,6 +38,7 @@ function track!(
   ramp_particle_energy_without_rf::Bool=false,
   ramp_update_each_particle::Bool=false,
   rf_on::Bool=true,
+  absolute_time_tracking::Bool=false,
   kwargs...
 )
   if length(bl.line) == 0
@@ -46,7 +48,7 @@ function track!(
   context = bl.context
   
   for ele in bl.line
-    track!(bunch, ele; context, scalar_params, ramp_particle_energy_without_rf, ramp_update_each_particle, rf_on, kwargs...)
+    track!(bunch, ele; context, scalar_params, ramp_particle_energy_without_rf, ramp_update_each_particle, rf_on, absolute_time_tracking, kwargs...)
   end
 
   return bunch

--- a/ext/BeamTrackingBeamlinesExt/general_bl.jl
+++ b/ext/BeamTrackingBeamlinesExt/general_bl.jl
@@ -75,11 +75,11 @@ end
 
 #---------------------------------------------------------------------------------------------------
 
-@inline function rfcavity(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, L)
+@inline function rfcavity(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, absolute_time_tracking, L)
   if !isactive(bmultipoleparams)
-    return pure_rf(tm, kc, p_over_q_ref, bunch, rfparams, beamlineparams, L)
+    return pure_rf(tm, kc, p_over_q_ref, bunch, rfparams, beamlineparams, absolute_time_tracking, L)
   else
-    return bmultipole_rf(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, L)
+    return bmultipole_rf(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, absolute_time_tracking, L)
   end
 end
 

--- a/ext/BeamTrackingBeamlinesExt/sagan_cavity_bl.jl
+++ b/ext/BeamTrackingBeamlinesExt/sagan_cavity_bl.jl
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------------------------------
 
-@inline function sagan_cavity(tm::SaganCavity, kc, p_over_q_ref, bunch, ele_name, bmultipoleP, rfP, beamlineP, L)
+@inline function sagan_cavity(tm::SaganCavity, kc, p_over_q_ref, bunch, ele_name, bmultipoleP, rfP, beamlineP, absolute_time_tracking, L)
   species = bunch.species
   mass = massof(species)
   q = chargeof(species)
@@ -16,7 +16,7 @@
 
   n_cells, L_active = rf_step_calc(tm.n_cells, tm.L_active, rf_omega, L)
   L_active <= L * (1 + eps(L)) || error("Cavity $ele_name, cannot have L_active ($L_active) greater than L ($L)." )
-  t_ref = 0    # bunch.t_ref ## Relative time tracking assumed for now.
+  t_ref = absolute_time_tracking ? bunch.t_ref : zero(bunch.t_ref)
   a = gyromagnetic_anomaly(species)
 
   #

--- a/ext/BeamTrackingBeamlinesExt/scibmadstandard_bl.jl
+++ b/ext/BeamTrackingBeamlinesExt/scibmadstandard_bl.jl
@@ -9,7 +9,7 @@ end
 # Note: for exact transformations, use Symplectic order 2 because higher orders won't increase accuracy
 @inline drift(tm::SciBmadStandard, kc, p_over_q_ref, bunch, L) = drift(sbs2s(tm; order=2), kc, p_over_q_ref, bunch, L) 
 
-@inline pure_rf(tm::SciBmadStandard, kc, p_over_q_ref, bunch, rfparams, beamlineparams, L)                = pure_rf(sbs2s(tm), kc, p_over_q_ref, bunch, rfparams, beamlineparams, L)                        
+@inline pure_rf(tm::SciBmadStandard, kc, p_over_q_ref, bunch, rfparams, beamlineparams, att, L)           = pure_rf(sbs2s(tm), kc, p_over_q_ref, bunch, rfparams, beamlineparams, att, L)
 @inline pure_bsolenoid(tm::SciBmadStandard, kc, p_over_q_ref, bunch, bm0, L)                              = pure_bsolenoid(sbs2s(tm; order=2), kc, p_over_q_ref, bunch, bm0, L)                             
 @inline bsolenoid(tm::SciBmadStandard, kc, p_over_q_ref, bunch, bmultipoleparams, L)                      = bsolenoid(sbs2s(tm), kc, p_over_q_ref, bunch, bmultipoleparams, L)                     
 @inline pure_bdipole(tm::SciBmadStandard, kc, p_over_q_ref, bunch, bm1, L)                                = pure_bdipole(sbs2s(tm; order=2), kc, p_over_q_ref, bunch, bm1, L)                               
@@ -18,7 +18,7 @@ end
 @inline bquadrupole(tm::SciBmadStandard, kc, p_over_q_ref, bunch, bmultipoleparams, L)                    = bquadrupole(sbs2s(tm), kc, p_over_q_ref, bunch, bmultipoleparams, L)                   
 @inline pure_bmultipole(tm::SciBmadStandard, kc, p_over_q_ref, bunch, bmk, L)                             = pure_bmultipole(sbs2s(tm), kc, p_over_q_ref, bunch, bmk, L)                            
 @inline bmultipole(tm::SciBmadStandard, kc, p_over_q_ref, bunch, bmultipoleparams, L)                     = bmultipole(sbs2s(tm), kc, p_over_q_ref, bunch, bmultipoleparams, L)                    
-@inline bmultipole_rf(tm::SciBmadStandard, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, L) = bmultipole_rf(sbs2s(tm), kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, L)
+@inline bmultipole_rf(tm::SciBmadStandard, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, att, L) = bmultipole_rf(sbs2s(tm), kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, att, L)
 @inline bend_no_field(tm::SciBmadStandard, kc, p_over_q_ref, bunch, bendparams, L)                        = bend_no_field(sbs2s(tm; order=2), kc, p_over_q_ref, bunch, bendparams, L)                       
 @inline bend_pure_bsolenoid(tm::SciBmadStandard, kc, p_over_q_ref, bunch, bendparams, bm0, L)             = bend_pure_bsolenoid(sbs2s(tm), kc, p_over_q_ref, bunch, bendparams, bm0, L)            
 @inline bend_bsolenoid(tm::SciBmadStandard, kc, p_over_q_ref, bunch, bendparams, bmultipoleparams, L)     = bend_bsolenoid(sbs2s(tm), kc, p_over_q_ref, bunch, bendparams, bmultipoleparams, L)    

--- a/ext/BeamTrackingBeamlinesExt/symplectic_bl.jl
+++ b/ext/BeamTrackingBeamlinesExt/symplectic_bl.jl
@@ -503,10 +503,13 @@ end
 
 
 # =========== RF ============= #
-@inline function thick_pure_rf(tm::Union{Symplectic,DriftKick}, kc, p_over_q_ref, bunch, rfparams, beamlineparams, L)
+@inline function thick_pure_rf(tm::Union{Symplectic,DriftKick}, kc, p_over_q_ref, bunch, rfparams, beamlineparams, absolute_time_tracking, L)
   p_over_q_ref = p_over_q_ref
   omega = rf_omega_calc(rfparams, beamlineparams)
   t_ref = (rf_phi0_calc(rfparams, beamlineparams.beamline.species_ref) - pi/2)/omega
+  if absolute_time_tracking
+    t_ref += bunch.t_ref
+  end
   tilde_m, gamsqr_0, beta_0 = BeamTracking.drift_params(bunch.species, p_over_q_ref)
   E0_normalized = rfparams.voltage/L/p_over_q_ref
   q = chargeof(bunch.species)
@@ -523,10 +526,13 @@ end
   return push(kc, integration_launcher(BeamTracking.cavity!, params, photon_params, tm, nothing, L))
 end
 
-@inline function thick_bmultipole_rf(tm::Union{Symplectic,DriftKick,SolenoidKick}, kc, p_over_q_ref, bunch, bm, rfparams, beamlineparams, L)
+@inline function thick_bmultipole_rf(tm::Union{Symplectic,DriftKick,SolenoidKick}, kc, p_over_q_ref, bunch, bm, rfparams, beamlineparams, absolute_time_tracking, L)
   p_over_q_ref = p_over_q_ref
   omega = rf_omega_calc(rfparams, beamlineparams)
   t_ref = (rf_phi0_calc(rfparams, beamlineparams.beamline.species_ref) - pi/2) / omega
+  if absolute_time_tracking
+    t_ref += bunch.t_ref
+  end
   tilde_m, gamsqr_0, beta_0 = BeamTracking.drift_params(bunch.species, p_over_q_ref)
   E0_normalized = rfparams.voltage/L/p_over_q_ref
   mm = bm.order

--- a/ext/BeamTrackingBeamlinesExt/unpack_bl.jl
+++ b/ext/BeamTrackingBeamlinesExt/unpack_bl.jl
@@ -9,7 +9,8 @@ function _track!(
   scalar_params,
   ramp_particle_energy_without_rf,
   ramp_update_each_particle,
-  rf_on;
+  rf_on,
+  absolute_time_tracking;
   kwargs...
 )
   # Unpack the line element (type unstable)
@@ -44,7 +45,7 @@ function _track!(
   end
 
   # Function barrier
-  universal!(coords, tm, ele, ramp_particle_energy_without_rf, ramp_update_each_particle, bunch, L, p_over_q_ref, ap, bp, bm, pp, dp, rp, lp, mp, fpp, em; kwargs...)
+  universal!(coords, tm, ele, ramp_particle_energy_without_rf, ramp_update_each_particle, absolute_time_tracking, bunch, L, p_over_q_ref, ap, bp, bm, pp, dp, rp, lp, mp, fpp, em; kwargs...)
 end
 
 # Step 2: Push particles through -----------------------------------------
@@ -54,6 +55,7 @@ function universal!(
   ele,
   ramp_particle_energy_without_rf, 
   ramp_update_each_particle,
+  absolute_time_tracking,
   bunch,
   L, 
   p_over_q_ref,
@@ -184,7 +186,7 @@ function universal!(
     end
     !rfparams.is_crabcavity || error("Crab cavities not yet supported for tracking")
 
-    kc = @inline(rfcavity(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, L))
+    kc = @inline(rfcavity(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, absolute_time_tracking, L))
     
   elseif isactive(bendparams)
     if bendparams.edge1_int != 0 || bendparams.edge2_int != 0; error("edge1_int and edge2_int not yet handled for tracking"); end
@@ -328,9 +330,9 @@ end
 #---------------------------------------------------------------------------------------------------
 # universal! for SaganCavity tracking.
 
-function universal!(coords, tm::SaganCavity, ele, ramp_particle_energy_without_rf, ramp_update_each_particle, bunch, L,
+function universal!(coords, tm::SaganCavity, ele, ramp_particle_energy_without_rf, ramp_update_each_particle, absolute_time_tracking, bunch, L,
   p_over_q_ref, alignmentparams, bendparams, bmultipoleparams, patchparams, apertureparams,
-  rfparams, beamlineparams, mapparams, fourpotentialparams, emultipoleparams; kwargs...) 
+  rfparams, beamlineparams, mapparams, fourpotentialparams, emultipoleparams; kwargs...)
 
   !isactive(mapparams) || error("SaganCavity Tracking through element $ele_name with MapParams is undefined")
   !isactive(patchparams) || error("SaganCavity Tracking through element $ele_name with PatchParams is undefined")
@@ -371,9 +373,9 @@ function universal!(coords, tm::SaganCavity, ele, ramp_particle_energy_without_r
         dt_ref += L_active / (n_cells * E_to_v(species, E_now_ref))
       end
     end
-    t_exit = dt_ref
+    t_exit = t_enter + dt_ref
   else
-    t_exit = 0
+    t_exit = t_enter
   end
   if p_over_q_ref isa TimeDependentParam
     beta_gamma_exit = R_to_beta_gamma(bunch.species, p_over_q_ref(t_exit))
@@ -414,7 +416,7 @@ function universal!(coords, tm::SaganCavity, ele, ramp_particle_energy_without_r
   end
 
   # Cavity tracking
-  kc = @inline(sagan_cavity(tm, kc, p_over_q_ref, bunch, ele.name, bmultipoleparams, rfparams, beamlineparams, L))
+  kc = @inline(sagan_cavity(tm, kc, p_over_q_ref, bunch, ele.name, bmultipoleparams, rfparams, beamlineparams, absolute_time_tracking, L))
 
   # Exit aperture and alignment
   if isactive(alignmentparams)
@@ -453,7 +455,7 @@ end
 # "Pure" means only ONE SINGLE multipole.
 # When "pure" is not present, it means that at least one HIGHER ORDER
 # multipole exists.
-@inline thin_pure_rf(tm, kc, p_over_q_ref, bunch, rfparams)                          = error("Undefined for tracking method $tm")
+@inline thin_pure_rf(tm, kc, p_over_q_ref, bunch, rfparams, att)                     = error("Undefined for tracking method $tm")
 @inline thin_pure_bsolenoid(tm, kc, p_over_q_ref, bunch, bm0)                        = error("Undefined for tracking method $tm")
 @inline thin_bsolenoid(tm, kc, p_over_q_ref, bunch, bmultipoleparams)                = error("Undefined for tracking method $tm")
 @inline thin_pure_bdipole(tm, kc, p_over_q_ref, bunch, bm1)                          = error("Undefined for tracking method $tm")
@@ -462,10 +464,10 @@ end
 @inline thin_bquadrupole(tm, kc, p_over_q_ref, bunch, bmultipoleparams)              = error("Undefined for tracking method $tm")
 @inline thin_pure_bmultipole(tm, kc, p_over_q_ref, bunch, bmk)                       = error("Undefined for tracking method $tm")
 @inline thin_bmultipole(tm, kc, p_over_q_ref, bunch, bmultipoleparams)               = error("Undefined for tracking method $tm")
-@inline thin_bmultipole_rf(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams)  = error("Undefined for tracking method $tm")
+@inline thin_bmultipole_rf(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, att) = error("Undefined for tracking method $tm")
 @inline thin_pure_edipole(tm, kc, p_over_q_ref, bunch, em1)                          = error("Undefined for tracking method $tm")
 
-@inline thick_pure_rf(tm, kc, p_over_q_ref, bunch, rfparams, beamlineparams, L)                         = error("Undefined for tracking method $tm")
+@inline thick_pure_rf(tm, kc, p_over_q_ref, bunch, rfparams, beamlineparams, att, L)                    = error("Undefined for tracking method $tm")
 @inline thick_pure_bsolenoid(tm, kc, p_over_q_ref, bunch, bm0, L)                                       = error("Undefined for tracking method $tm")
 @inline thick_bsolenoid(tm, kc, p_over_q_ref, bunch, bmultipoleparams, L)                               = error("Undefined for tracking method $tm")
 @inline thick_pure_bdipole(tm, kc, p_over_q_ref, bunch, bm1, L)                                         = error("Undefined for tracking method $tm")
@@ -474,7 +476,7 @@ end
 @inline thick_bquadrupole(tm, kc, p_over_q_ref, bunch, bmultipoleparams, L)                             = error("Undefined for tracking method $tm")
 @inline thick_pure_bmultipole(tm, kc, p_over_q_ref, bunch, bmk, L)                                      = error("Undefined for tracking method $tm")
 @inline thick_bmultipole(tm, kc, p_over_q_ref, bunch, bmultipoleparams, L)                              = error("Undefined for tracking method $tm")
-@inline thick_bmultipole_rf(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, L) = error("Undefined for tracking method $tm")
+@inline thick_bmultipole_rf(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, att, L) = error("Undefined for tracking method $tm")
 @inline thick_pure_edipole(tm, kc, p_over_q_ref, bunch, em1, L)                                         = error("Undefined for tracking method $tm")
 
 # === Elements with curving coordinate system "bend" === #
@@ -508,7 +510,7 @@ end
 
 
 # === Elements thin vs thick check === #
-@inline pure_rf(tm, kc, p_over_q_ref, bunch, rfparams, beamlineparams, L)                          = L == 0 ? thin_pure_rf(tm, kc, p_over_q_ref, bunch, rfparams, beamlineparams)                         : thick_pure_rf(tm, kc, p_over_q_ref, bunch, rfparams, beamlineparams, L)
+@inline pure_rf(tm, kc, p_over_q_ref, bunch, rfparams, beamlineparams, att, L)                = L == 0 ? thin_pure_rf(tm, kc, p_over_q_ref, bunch, rfparams, beamlineparams, att)               : thick_pure_rf(tm, kc, p_over_q_ref, bunch, rfparams, beamlineparams, att, L)
 @inline pure_bsolenoid(tm, kc, p_over_q_ref, bunch, bm0, L)                                   = L == 0 ? thin_pure_bsolenoid(tm, kc, p_over_q_ref, bunch, bm0)                                  : thick_pure_bsolenoid(tm, kc, p_over_q_ref, bunch, bm0, L)      
 @inline bsolenoid(tm, kc, p_over_q_ref, bunch, bmultipoleparams, L)                           = L == 0 ? thin_bsolenoid(tm, kc, p_over_q_ref, bunch, bmultipoleparams)                          : thick_bsolenoid(tm, kc, p_over_q_ref, bunch, bmultipoleparams, L)       
 @inline pure_bdipole(tm, kc, p_over_q_ref, bunch, bm1, L)                                     = L == 0 ? thin_pure_bdipole(tm, kc, p_over_q_ref, bunch, bm1)                                    : thick_pure_bdipole(tm, kc, p_over_q_ref, bunch, bm1, L)          
@@ -517,7 +519,7 @@ end
 @inline bquadrupole(tm, kc, p_over_q_ref, bunch, bmultipoleparams, L)                         = L == 0 ? thin_bquadrupole(tm, kc, p_over_q_ref, bunch, bmultipoleparams)                        : thick_bquadrupole(tm, kc, p_over_q_ref, bunch, bmultipoleparams, L)           
 @inline pure_bmultipole(tm, kc, p_over_q_ref, bunch, bmk, L)                                  = L == 0 ? thin_pure_bmultipole(tm, kc, p_over_q_ref, bunch, bmk)                                 : thick_pure_bmultipole(tm, kc, p_over_q_ref, bunch, bmk, L)                   
 @inline bmultipole(tm, kc, p_over_q_ref, bunch, bmultipoleparams, L)                          = L == 0 ? thin_bmultipole(tm, kc, p_over_q_ref, bunch, bmultipoleparams)                         : thick_bmultipole(tm, kc, p_over_q_ref, bunch, bmultipoleparams, L)
-@inline bmultipole_rf(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, L)  = L == 0 ? thin_bmultipole_rf(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams) : thick_bmultipole_rf(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, L)        
+@inline bmultipole_rf(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, att, L) = L == 0 ? thin_bmultipole_rf(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, att) : thick_bmultipole_rf(tm, kc, p_over_q_ref, bunch, bmultipoleparams, rfparams, beamlineparams, att, L)
 @inline bend_no_field(tm, kc, p_over_q_ref, bunch, bendparams, L)                             = L == 0 ? thin_bend_no_field(tm, kc, p_over_q_ref, bunch, bendparams)                            : thick_bend_no_field(tm, kc, p_over_q_ref, bunch, bendparams, L)
 @inline bend_pure_bsolenoid(tm, kc, p_over_q_ref, bunch, bendparams, bm0, L)                  = L == 0 ? thin_bend_pure_bsolenoid(tm, kc, p_over_q_ref, bunch, bendparams, bm0)                 : thick_bend_pure_bsolenoid(tm, kc, p_over_q_ref, bunch, bendparams, bm0, L)      
 @inline bend_bsolenoid(tm, kc, p_over_q_ref, bunch, bendparams, bmultipoleparams, L)          = L == 0 ? thin_bend_bsolenoid(tm, kc, p_over_q_ref, bunch, bendparams, bmultipoleparams)         : thick_bend_bsolenoid(tm, kc, p_over_q_ref, bunch, bendparams, bmultipoleparams, L)         
@@ -527,4 +529,4 @@ end
 @inline bend_bquadrupole(tm, kc, p_over_q_ref, bunch, bendparams, bmultipoleparams, L)        = L == 0 ? thin_bend_bquadrupole(tm, kc, p_over_q_ref, bunch, bendparams, bmultipoleparams)       : thick_bend_bquadrupole(tm, kc, p_over_q_ref, bunch, bendparams, bmultipoleparams, L)           
 @inline bend_pure_bmultipole(tm, kc, p_over_q_ref, bunch, bendparams, bmk, L)                 = L == 0 ? thin_bend_pure_bmultipole(tm, kc, p_over_q_ref, bunch, bendparams, bmk)                : thick_bend_pure_bmultipole(tm, kc, p_over_q_ref, bunch, bendparams, bmk, L)                   
 @inline bend_bmultipole(tm, kc, p_over_q_ref, bunch, bendparams, bmultipoleparams, L)         = L == 0 ? thin_bend_bmultipole(tm, kc, p_over_q_ref, bunch, bendparams, bmultipoleparams)        : thick_bend_bmultipole(tm, kc, p_over_q_ref, bunch, bendparams, bmultipoleparams, L)      
-@inline pure_edipole(tm, kc, p_over_q_ref, bunch, em1, L)                                     = L == 0 ? thin_pure_edipole(tm, kc, p_over_q_ref, bunch, em1)                                    : thick_pure_edipole(tm, kc, p_over_q_ref, bunch, em1, L)                          
+@inline pure_edipole(tm, kc, p_over_q_ref, bunch, em1, L)                                     = L == 0 ? thin_pure_edipole(tm, kc, p_over_q_ref, bunch, em1)                                    : thick_pure_edipole(tm, kc, p_over_q_ref, bunch, em1, L)

--- a/test/BeamlinesExt/beamlines_sagan_cavity_test.jl
+++ b/test/BeamlinesExt/beamlines_sagan_cavity_test.jl
@@ -98,6 +98,34 @@ R0 = BT.E_to_R(species, E0)
   @test b1.coords.v ≈ out7
   @test b1.coords.q ≈ qout7
   @test b1.t_ref ≈ 6.6712819118982366e-9
+
+  ele1 = sc8
+  ele2 = sc9
+  b1 = Bunch(copy(v1), deepcopy(quat1), species=species, p_over_q_ref=BT.E_to_R(species, ele1.E_ref-ele1.dE_ref), t_ref=1 / (8 * ele1.rf_frequency))
+  b2  = Bunch(copy(v1), deepcopy(quat1), species=species, p_over_q_ref=BT.E_to_R(species, ele2.E_ref-ele2.dE_ref))
+  track!(b1, ele1; absolute_time_tracking = true)
+  track!(b2, ele2)
+  if printit; println(b1.coords.v); end
+  if printit; println(b2.coords.v); end
+  if printit; println(b1.coords.q); end
+  if printit; println(b2.coords.q); end
+  @test b1.coords.v ≈ b2.coords.v
+  @test b1.t_ref ≈ 6.7962819118767384e-9
+  @test b2.t_ref ≈ 6.671281911876738e-9
+  
+
+  ele = sc8
+  b1 = Bunch(copy(v1), species=species, p_over_q_ref = BT.E_to_R(species, ele.E_ref-ele.dE_ref), t_ref = 1 / (8 * ele1.rf_frequency))
+  b2 = Bunch(copy(v1), species=species, p_over_q_ref = BT.E_to_R(species, ele.E_ref-ele.dE_ref))
+  track!(b1, ele)
+  track!(b2, ele)
+  if printit; println(b1.coords.v); end
+  if printit; println(b2.coords.v); end
+  if printit; println(b1.coords.q); end
+  if printit; println(b2.coords.q); end
+  @test b1.coords.v ≈ b2.coords.v
+  @test b1.t_ref ≈ 6.7962819118767384e-9
+  @test b2.t_ref ≈ 6.671281911876738e-9
 end
 
 # dE_ref

--- a/test/BeamlinesExt_symplectic_test.jl
+++ b/test/BeamlinesExt_symplectic_test.jl
@@ -508,6 +508,30 @@
     @test b0.coords.v ≈ v_expected
     @test b0.coords.q ≈ q_expected
 
+    # Relative time tracking is independent of bunch.t_ref
+    v = [0.01 0.02 0.03 0.04 0.05 0.06]
+    q = [1.0 0.0 0.0 0.0]
+    b_relative = Bunch(v, q, p_over_q_ref=p_over_q_ref, species=Species("electron"), t_ref=phase_time)
+    track!(b_relative, bl)
+    @test b_relative.coords.v ≈ b0.coords.v
+    @test b_relative.coords.q ≈ b0.coords.q
+
+    # Absolute-time RF phase is equivalent to shifting phi0 by omega * bunch.t_ref.
+    rf_frequency = 5.9114268014977E8
+    phase_time = 1 / (8 * rf_frequency)
+    ele_absolute = LineElement(L=4.01667, voltage=3.3210942126011E6, rf_frequency=rf_frequency, phi0=0.0, tracking_method=Symplectic(order=2))
+    ele_shifted = LineElement(L=4.01667, voltage=3.3210942126011E6, rf_frequency=rf_frequency, phi0=2*pi*rf_frequency*phase_time, tracking_method=Symplectic(order=2))
+    bl_absolute = Beamline([ele_absolute], p_over_q_ref=p_over_q_ref, species_ref=Species("electron"))
+    bl_shifted = Beamline([ele_shifted], p_over_q_ref=p_over_q_ref, species_ref=Species("electron"))
+    v = [0.01 0.02 0.03 0.04 0.05 0.06]
+    q = [1.0 0.0 0.0 0.0]
+    b_absolute = Bunch(copy(v), copy(q), p_over_q_ref=p_over_q_ref, species=Species("electron"), t_ref=phase_time)
+    b_shifted = Bunch(copy(v), copy(q), p_over_q_ref=p_over_q_ref, species=Species("electron"))
+    track!(b_absolute, bl_absolute; absolute_time_tracking=true)
+    track!(b_shifted, bl_shifted)
+    @test b_absolute.coords.v ≈ b_shifted.coords.v
+    @test b_absolute.coords.q ≈ b_shifted.coords.q
+
     # Harmon:
     ele_drift = LineElement(L=1.04812778909)
     ele = LineElement(L=4.01667, voltage=3.3210942126011E6, harmon=10, zero_phase=PhaseRef.AboveTransition, tracking_method=Symplectic(order=2))

--- a/test/BeamlinesExt_symplectic_test.jl
+++ b/test/BeamlinesExt_symplectic_test.jl
@@ -511,7 +511,7 @@
     # Relative time tracking is independent of bunch.t_ref
     v = [0.01 0.02 0.03 0.04 0.05 0.06]
     q = [1.0 0.0 0.0 0.0]
-    b_relative = Bunch(v, q, p_over_q_ref=p_over_q_ref, species=Species("electron"), t_ref=phase_time)
+    b_relative = Bunch(v, q, p_over_q_ref=p_over_q_ref, species=Species("electron"), t_ref=0.1234)
     track!(b_relative, bl)
     @test b_relative.coords.v ≈ b0.coords.v
     @test b_relative.coords.q ≈ b0.coords.q

--- a/test/lattices/sagan_cavity_lat.jl
+++ b/test/lattices/sagan_cavity_lat.jl
@@ -30,9 +30,23 @@ end
   m3 = Marker(E_ref = E0, species_ref = species)
 end
 
+@elements begin
+  sc8 = RFCavity(L = 2.0, voltage = 0.2*E0, rf_frequency =1e9, dE_ref = 0.1*E0, 
+                  tracking_method = SaganCavity(n_cells = 2), traveling_wave = false, phi0 = 0.1)
+  m4 = Marker(E_ref = E0, species_ref = species)
+end
+
+  @elements begin
+  sc9 = RFCavity(L = 2.0, voltage = 0.2*E0, rf_frequency =1e9, dE_ref = 0.1*E0, 
+                  tracking_method = SaganCavity(n_cells = 2), traveling_wave = false, phi0 = 0.1 + 2*pi/8)
+  m5 = Marker(E_ref = E0, species_ref = species)
+end
+
 lat = Branch([m, sc1, sc2, sc3])
 lat2 = Branch([m2, sc4, sc5, sc6])
 lat3 = Branch([m3, sc7])
+lat4 = Branch([m4, sc8])
+lat5 = Branch([m5, sc9])
 
 # Beamlines v0.9.0 shallow copy:
 sc1 = lat.beamlines[2].line[1]
@@ -44,5 +58,7 @@ sc5 = lat2.beamlines[3].line[1]
 sc6 = lat2.beamlines[4].line[1]
 
 sc7 = lat3.beamlines[2].line[1]
+sc8 = lat4.beamlines[2].line[1]
+sc9 = lat5.beamlines[2].line[1]
 
 ;


### PR DESCRIPTION
This is a minimal extension to RF tracking to take `bunch.t_ref` into account when calculating RF phase.

Adds an `absolute_time_tracking` flag for `track!` which is propagated downstream.

This is needed in SciBmad's `find_closed_orbit` and `twiss` so that "radial steering" is possible by manipulating RF frequency.